### PR TITLE
Update views.py

### DIFF
--- a/deviantart/views.py
+++ b/deviantart/views.py
@@ -1,5 +1,5 @@
 from django.http.response import HttpResponseServerError
-from django.shortcuts import redirect, render_to_response, reverse
+from django.shortcuts import redirect, render, reverse
 
 from .oauth import Deviantart
 
@@ -33,4 +33,4 @@ def endpoint(request, dapath):
     if json.get('error_code', 200) >= 400:
         return HttpResponseServerError(status=status_code)
 
-    return render_to_response('deviantart/endpoint.html', json)
+    return render(request, 'deviantart/endpoint.html', json)


### PR DESCRIPTION
The "render_to_response" shortcut was deprecated in [Django 2.0](https://docs.djangoproject.com/en/3.0/releases/3.0/#features-removed-in-3-0) (2017), and is removed in [Django 3.0](https://docs.djangoproject.com/en/3.0/releases/3.0/#features-removed-in-3-0)(Dec, 2019)